### PR TITLE
Fix thumbnail info and centering

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -104,18 +104,17 @@ export const uploadFilesPresigned = async (files, onUploadProgress) => {
         });
 
         thumbnailsMeta.push({
-          fileName: file.name,
+          fileName: thumbPath ? thumbPath.split('/').pop() : file.name,
           originalName: original.name,
           mimeType: file.type,
           fileType: file.type,
-          size: file.size,
+          size,
           path: thumbPath,
-          thumbnailSize: size,
         });
       }
 
       meta.push({
-        fileName: original.name,
+        fileName: originalPath ? originalPath.split('/').pop() : original.name,
         originalName: original.name,
         mimeType: original.type,
         fileType: original.type,

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -145,7 +145,9 @@ export const generateThumbnails = async (file) => {
       const ratio = Math.min(width / imageBitmap.width, height / imageBitmap.height);
       const w = imageBitmap.width * ratio;
       const h = imageBitmap.height * ratio;
-      ctx.drawImage(imageBitmap, 0, 0, w, h);
+      const x = (width - w) / 2;
+      const y = (height - h) / 2;
+      ctx.drawImage(imageBitmap, x, y, w, h);
       return new Promise((resolve) =>
         canvas.toBlob((blob) => resolve({ size, blob }), 'image/webp')
       );


### PR DESCRIPTION
## Summary
- center thumbnails on canvas and keep them transparent
- send thumbnail metadata with correct size enum and hashed filenames

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e0d15538832392a163f4898af396