### PR TITLE
Add form management interface

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,6 +45,9 @@ const BoardTypesPage = lazy(()=>import('./pages/BoardTypesPage'));
 const VideosPage = lazy(()=>import('./pages/VideosPage'));
 const IKKPage = lazy(()=>import('./pages/IKKPage'));
 const ExpertisePage = lazy(()=>import('./pages/expertisePage')); // Lazy import for ExpertisePage
+const FormBuilderPage = lazy(()=>import('./pages/FormBuilderPage'));
+const FormListPage = lazy(()=>import('./pages/FormListPage'));
+const FormFillPage = lazy(()=>import('./pages/FormFillPage'));
 
 function App() {
   return (
@@ -88,6 +91,9 @@ function App() {
                 <Route path='/board-types' element={<BoardTypesPage />} />
                 <Route path='/ikk' element={<IKKPage />} />
                 <Route path='/expertise' element={<ExpertisePage />} /> {/* Add the new route */}
+                <Route path='/form/:id?' element={<FormBuilderPage />} />
+                <Route path='/forms' element={<FormListPage />} />
+                <Route path='/form/:id/fill' element={<FormFillPage />} />
                 <Route path="*" element={<UnderConstructionPage />} />
               </Route>
             </Routes>

--- a/src/api.js
+++ b/src/api.js
@@ -1216,3 +1216,39 @@ export const deleteExpertise = async (id) => {
     throw error;
   }
 };
+
+// ----- Forms API -----
+export const createForm = async (data) => {
+  const response = await instance.post('/api/forms', data);
+  return response.data;
+};
+
+export const updateForm = async (id, data) => {
+  const response = await instance.put(`/api/forms/${id}`, data);
+  return response.data;
+};
+
+export const getForms = async (params = {}) => {
+  const response = await instance.get('/api/forms', { params });
+  return response.data;
+};
+
+export const getFormById = async (id) => {
+  const response = await instance.get(`/api/forms/${id}`);
+  return response.data;
+};
+
+export const deleteForm = async (id) => {
+  const response = await instance.delete(`/api/forms/${id}`);
+  return response.data;
+};
+
+export const createSubmission = async (formId, data) => {
+  const response = await instance.post(`/api/forms/${formId}/submissions`, data);
+  return response.data;
+};
+
+export const getSubmissions = async (formId, params = {}) => {
+  const response = await instance.get(`/api/forms/${formId}/submissions`, { params });
+  return response.data;
+};

--- a/src/components/apiForms/FormBuilder.js
+++ b/src/components/apiForms/FormBuilder.js
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Button, TextField, Select, MenuItem, FormControlLabel, Checkbox, IconButton, Typography, Paper, Grid } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { createForm, updateForm, getFormById } from '../../api';
+
+const emptyField = {
+  name: '',
+  label: '',
+  type: 'text',
+  required: false,
+  options: [],
+  minLength: '',
+  maxLength: '',
+  minValue: '',
+  maxValue: '',
+  minChoices: 0,
+  maxChoices: '',
+  regex: ''
+};
+
+const fieldTypes = ['text','number','select','multiselect','radio','date','datetime','html'];
+
+function FieldEditor({ field, onChange, onDelete }) {
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    onChange({ ...field, [name]: type === 'checkbox' ? checked : value });
+  };
+
+  return (
+    <Paper sx={{ p:2, mb:2 }}>
+      <Grid container spacing={2} alignItems="center">
+        <Grid item xs={11}>
+          <TextField label="Field Name" name="name" value={field.name} onChange={handleChange} fullWidth sx={{ mb:1 }} />
+          <TextField label="Label" name="label" value={field.label} onChange={handleChange} fullWidth sx={{ mb:1 }} />
+          <Select name="type" value={field.type} onChange={handleChange} fullWidth sx={{ mb:1 }}>
+            {fieldTypes.map(t => <MenuItem key={t} value={t}>{t}</MenuItem>)}
+          </Select>
+          {(field.type === 'select' || field.type === 'multiselect' || field.type === 'radio') && (
+            <TextField label="Options (comma separated)" name="options" value={field.options.join(',')} onChange={e => onChange({ ...field, options:e.target.value.split(',') })} fullWidth sx={{ mb:1 }} />
+          )}
+          <TextField label="Regex" name="regex" value={field.regex||''} onChange={handleChange} fullWidth sx={{ mb:1 }} />
+          <FormControlLabel control={<Checkbox checked={field.required} onChange={handleChange} name="required"/>} label="Required" />
+        </Grid>
+        <Grid item xs={1}>
+          <IconButton onClick={onDelete}><DeleteIcon /></IconButton>
+        </Grid>
+      </Grid>
+    </Paper>
+  );
+}
+
+export default function FormBuilder({ formId, onSaved }) {
+  const [name, setName] = useState('');
+  const [fields, setFields] = useState([]);
+
+  useEffect(() => {
+    if(formId) {
+      getFormById(formId).then(data => {
+        setName(data.name);
+        setFields(data.fields || []);
+      });
+    }
+  }, [formId]);
+
+  const addField = () => setFields([...fields, { ...emptyField, name:`field${fields.length+1}` }]);
+  const updateField = (index, field) => {
+    const updated = [...fields];
+    updated[index] = field;
+    setFields(updated);
+  };
+  const deleteField = (index) => setFields(fields.filter((_,i)=>i!==index));
+
+  const handleSave = async () => {
+    const form = { name, fields };
+    if(formId) await updateForm(formId, form); else await createForm(form);
+    if(onSaved) onSaved();
+  };
+
+  // simple drag and drop handlers
+  const onDragStart = (e, index) => {
+    e.dataTransfer.setData('text/plain', index);
+  };
+  const onDrop = (e, index) => {
+    const from = e.dataTransfer.getData('text/plain');
+    if(from === '') return;
+    const updated = [...fields];
+    const moved = updated.splice(from,1)[0];
+    updated.splice(index,0,moved);
+    setFields(updated);
+  };
+  const onDragOver = (e) => e.preventDefault();
+
+  return (
+    <Box>
+      <TextField label="Form Name" value={name} onChange={e=>setName(e.target.value)} fullWidth sx={{ mb:2 }} />
+      {fields.map((f,idx) => (
+        <div key={idx} draggable onDragStart={(e)=>onDragStart(e, idx)} onDragOver={onDragOver} onDrop={(e)=>onDrop(e, idx)}>
+          <FieldEditor field={f} onChange={fld=>updateField(idx,fld)} onDelete={()=>deleteField(idx)} />
+        </div>
+      ))}
+      <Button onClick={addField}>Add Field</Button>
+      <Button variant="contained" onClick={handleSave} sx={{ ml:2 }}>Save Form</Button>
+    </Box>
+  );
+}

--- a/src/components/apiForms/FormFill.js
+++ b/src/components/apiForms/FormFill.js
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import { Box, TextField, Checkbox, FormControlLabel, Select, MenuItem, Button } from '@mui/material';
+import { getFormById, createSubmission } from '../../api';
+import { useParams } from 'react-router-dom';
+
+function renderField(field, value, setValue) {
+  const handleChange = (e) => {
+    const val = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+    setValue(val);
+  };
+
+  switch(field.type) {
+    case 'text':
+      return <TextField label={field.label} value={value||''} onChange={handleChange} fullWidth sx={{mb:2}} />;
+    case 'number':
+      return <TextField type="number" label={field.label} value={value||''} onChange={handleChange} fullWidth sx={{mb:2}} />;
+    case 'select':
+      return (
+        <Select value={value||''} onChange={handleChange} fullWidth sx={{mb:2}}>
+          {field.options.map(opt=> <MenuItem key={opt} value={opt}>{opt}</MenuItem>)}
+        </Select>
+      );
+    case 'multiselect':
+      return (
+        <Select multiple value={value||[]} onChange={handleChange} fullWidth sx={{mb:2}}>
+          {field.options.map(opt=> <MenuItem key={opt} value={opt}>{opt}</MenuItem>)}
+        </Select>
+      );
+    case 'radio':
+      return (
+        <Box sx={{mb:2}}>
+          {field.options.map(opt => (
+            <FormControlLabel key={opt} control={<Checkbox checked={value===opt} onChange={()=>setValue(opt)} />} label={opt} />
+          ))}
+        </Box>
+      );
+    case 'date':
+    case 'datetime':
+      return <TextField type="date" label={field.label} value={value||''} onChange={handleChange} fullWidth sx={{mb:2}} />;
+    case 'html':
+      return <TextField multiline label={field.label} value={value||''} onChange={handleChange} fullWidth sx={{mb:2}} />;
+    default:
+      return null;
+  }
+}
+
+export default function FormFill() {
+  const { id } = useParams();
+  const [form, setForm] = useState(null);
+  const [values, setValues] = useState({});
+
+  useEffect(() => {
+    getFormById(id).then(data => setForm(data));
+  }, [id]);
+
+  const handleSubmit = async () => {
+    await createSubmission(id, values);
+    alert('Submitted');
+  };
+
+  if(!form) return null;
+
+  return (
+    <Box>
+      <h2>{form.name}</h2>
+      {form.fields.map(f => {
+        const value = values[f.name];
+        return (
+          <div key={f.name}>
+            {renderField(f, value, val=>setValues({...values, [f.name]:val}))}
+          </div>
+        );
+      })}
+      <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+    </Box>
+  );
+}

--- a/src/components/apiForms/FormList.js
+++ b/src/components/apiForms/FormList.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, IconButton, TextField, Pagination, Button } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { getForms, deleteForm } from '../../api';
+import { useNavigate } from 'react-router-dom';
+
+export default function FormList() {
+  const [forms, setForms] = useState([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(0);
+  const [search, setSearch] = useState('');
+  const limit = 10;
+  const navigate = useNavigate();
+
+  useEffect(() => { fetchForms(); }, [page, search]);
+
+  const fetchForms = async () => {
+    const data = await getForms({ search, page, limit });
+    setForms(data.forms || []);
+    setTotalPages(Math.ceil((data.total || 0) / limit));
+  };
+
+  const handleDelete = async (id, submissions) => {
+    if(submissions>0) return;
+    await deleteForm(id);
+    fetchForms();
+  };
+
+  return (
+    <TableContainer>
+      <TextField placeholder="Search" value={search} onChange={e=>setSearch(e.target.value)} sx={{ my:2 }} />
+      <Button onClick={()=>navigate('/form')}>New Form</Button>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Created</TableCell>
+            <TableCell>Submissions</TableCell>
+            <TableCell>Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {forms.map(form => (
+            <TableRow key={form._id}>
+              <TableCell>{form.name}</TableCell>
+              <TableCell>{new Date(form.createdAt).toLocaleDateString()}</TableCell>
+              <TableCell>{form.submissionCount || 0}</TableCell>
+              <TableCell>
+                <IconButton onClick={()=>navigate(`/form/${form._id}`)}><EditIcon/></IconButton>
+                <IconButton onClick={()=>handleDelete(form._id, form.submissionCount)} disabled={form.submissionCount>0}><DeleteIcon/></IconButton>
+                <Button size="small" onClick={()=>navigate(`/form/${form._id}/fill`)}>Test</Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <Pagination count={totalPages} page={page} onChange={(e,v)=>setPage(v)} sx={{my:2}} />
+    </TableContainer>
+  );
+}

--- a/src/components/menuItems/useMenuItems.js
+++ b/src/components/menuItems/useMenuItems.js
@@ -346,12 +346,45 @@ const expertiseMenu = {
   ]
 };
 
+  const formsMenu = {
+    id: 'forms',
+    title: t('Forms'),
+    type: 'group',
+    children: [
+      {
+        id: 'formPages',
+        title: t('Forms'),
+        type: 'collapse',
+        icon: ExplicitIcon,
+        children: [
+          {
+            id: 'newForm',
+            title: t('New Form'),
+            type: 'item',
+            url: '/form',
+            target: true,
+            requiredPermission: ['createForm']
+          },
+          {
+            id: 'formList',
+            title: t('Forms'),
+            type: 'item',
+            url: '/forms',
+            target: true,
+            requiredPermission: ['viewForms']
+          }
+        ]
+      }
+    ]
+  };
+
 const menuItems = {
   items: [
     dashboard,
     pages,
     users,
     events,
+    formsMenu,
     expertiseMenu,
     settings,
     celebration,

--- a/src/pages/FormBuilderPage.js
+++ b/src/pages/FormBuilderPage.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Container, Typography } from '@mui/material';
+import FormBuilder from '../components/apiForms/FormBuilder';
+import { useNavigate, useParams } from 'react-router-dom';
+
+export default function FormBuilderPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  return (
+    <Container sx={{ p:4 }}>
+      <Typography variant="h4" gutterBottom>{id ? 'Edit Form' : 'New Form'}</Typography>
+      <FormBuilder formId={id} onSaved={()=>navigate('/forms')} />
+    </Container>
+  );
+}

--- a/src/pages/FormFillPage.js
+++ b/src/pages/FormFillPage.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Container } from '@mui/material';
+import FormFill from '../components/apiForms/FormFill';
+
+export default function FormFillPage() {
+  return (
+    <Container sx={{p:4}}>
+      <FormFill />
+    </Container>
+  );
+}

--- a/src/pages/FormListPage.js
+++ b/src/pages/FormListPage.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Container, Typography } from '@mui/material';
+import FormList from '../components/apiForms/FormList';
+
+export default function FormListPage() {
+  return (
+    <Container sx={{ p:4 }}>
+      <Typography variant="h4" gutterBottom>Forms</Typography>
+      <FormList />
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- add frontend components to build, list and test forms
- expose form endpoints in api wrapper
- add form pages and register them with routes
- include forms in side menu

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb5dd6648323b10ec1c4ccd88c6f