### PR TITLE
Add advanced form builder options

### DIFF
--- a/src/components/apiForms/FormFill.js
+++ b/src/components/apiForms/FormFill.js
@@ -1,44 +1,135 @@
-import React, { useEffect, useState } from 'react';
-import { Box, TextField, Checkbox, FormControlLabel, Select, MenuItem, Button } from '@mui/material';
-import { getFormById, createSubmission } from '../../api';
-import { useParams } from 'react-router-dom';
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  TextField,
+  Checkbox,
+  FormControlLabel,
+  Select,
+  MenuItem,
+  Button,
+  Alert,
+} from "@mui/material";
+import { getFormById, createSubmission } from "../../api";
+import { useParams } from "react-router-dom";
 
-function renderField(field, value, setValue) {
+function replacePlaceholders(text, values) {
+  return text.replace(/\{(\w+)\}/g, (_, k) => values[k] ?? "");
+}
+
+function renderField(field, value, setValue, error) {
   const handleChange = (e) => {
-    const val = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+    const val =
+      e.target.type === "checkbox" ? e.target.checked : e.target.value;
     setValue(val);
   };
 
-  switch(field.type) {
-    case 'text':
-      return <TextField label={field.label} value={value||''} onChange={handleChange} fullWidth sx={{mb:2}} />;
-    case 'number':
-      return <TextField type="number" label={field.label} value={value||''} onChange={handleChange} fullWidth sx={{mb:2}} />;
-    case 'select':
+  switch (field.type) {
+    case "text":
       return (
-        <Select value={value||''} onChange={handleChange} fullWidth sx={{mb:2}}>
-          {field.options.map(opt=> <MenuItem key={opt} value={opt}>{opt}</MenuItem>)}
+        <TextField
+          label={field.label}
+          value={value || ""}
+          onChange={handleChange}
+          required={field.required}
+          error={error}
+          multiline={field.multiline}
+          rows={field.multiline ? field.rows || 3 : undefined}
+          fullWidth
+          sx={{ mb: 2 }}
+        />
+      );
+    case "number":
+      return (
+        <TextField
+          type="number"
+          label={field.label}
+          value={value || ""}
+          onChange={handleChange}
+          required={field.required}
+          error={error}
+          fullWidth
+          sx={{ mb: 2 }}
+        />
+      );
+    case "select":
+      return (
+        <Select
+          value={value || ""}
+          onChange={handleChange}
+          required={field.required}
+          fullWidth
+          sx={{ mb: 2 }}
+          error={error}
+        >
+          {field.options.map((opt) => (
+            <MenuItem key={opt} value={opt}>
+              {opt}
+            </MenuItem>
+          ))}
         </Select>
       );
-    case 'multiselect':
+    case "multiselect":
       return (
-        <Select multiple value={value||[]} onChange={handleChange} fullWidth sx={{mb:2}}>
-          {field.options.map(opt=> <MenuItem key={opt} value={opt}>{opt}</MenuItem>)}
+        <Select
+          multiple
+          value={value || []}
+          onChange={handleChange}
+          required={field.required}
+          fullWidth
+          sx={{ mb: 2 }}
+          error={error}
+        >
+          {field.options.map((opt) => (
+            <MenuItem key={opt} value={opt}>
+              {opt}
+            </MenuItem>
+          ))}
         </Select>
       );
-    case 'radio':
+    case "radio":
       return (
-        <Box sx={{mb:2}}>
-          {field.options.map(opt => (
-            <FormControlLabel key={opt} control={<Checkbox checked={value===opt} onChange={()=>setValue(opt)} />} label={opt} />
+        <Box sx={{ mb: 2 }}>
+          {field.options.map((opt) => (
+            <FormControlLabel
+              key={opt}
+              control={
+                <Checkbox
+                  checked={value === opt}
+                  onChange={() => setValue(opt)}
+                />
+              }
+              label={opt}
+            />
           ))}
         </Box>
       );
-    case 'date':
-    case 'datetime':
-      return <TextField type="date" label={field.label} value={value||''} onChange={handleChange} fullWidth sx={{mb:2}} />;
-    case 'html':
-      return <TextField multiline label={field.label} value={value||''} onChange={handleChange} fullWidth sx={{mb:2}} />;
+    case "date":
+    case "datetime":
+      return (
+        <TextField
+          type="date"
+          label={field.label}
+          value={value || ""}
+          onChange={handleChange}
+          required={field.required}
+          error={error}
+          fullWidth
+          sx={{ mb: 2 }}
+        />
+      );
+    case "html":
+      return (
+        <TextField
+          multiline
+          label={field.label}
+          value={value || ""}
+          onChange={handleChange}
+          required={field.required}
+          error={error}
+          fullWidth
+          sx={{ mb: 2 }}
+        />
+      );
     default:
       return null;
   }
@@ -48,30 +139,71 @@ export default function FormFill() {
   const { id } = useParams();
   const [form, setForm] = useState(null);
   const [values, setValues] = useState({});
+  const [errors, setErrors] = useState({});
+  const [resultMsg, setResultMsg] = useState("");
+  const [resultError, setResultError] = useState(false);
 
   useEffect(() => {
-    getFormById(id).then(data => setForm(data));
+    getFormById(id).then((data) => setForm(data));
   }, [id]);
 
   const handleSubmit = async () => {
-    await createSubmission(id, values);
-    alert('Submitted');
+    const err = {};
+    form.fields.forEach((f) => {
+      if (f.required) {
+        const val = values[f.name];
+        if (
+          val === undefined ||
+          val === "" ||
+          (Array.isArray(val) && val.length === 0)
+        ) {
+          err[f.name] = true;
+        }
+      }
+    });
+    setErrors(err);
+    if (Object.keys(err).length > 0) return;
+
+    try {
+      await createSubmission(id, values);
+      const msg = form.successMessage || "Submitted";
+      setResultMsg(replacePlaceholders(msg, values));
+      setResultError(false);
+    } catch (e) {
+      const msg = form.failureMessage || "Submission failed";
+      setResultMsg(
+        replacePlaceholders(msg, values) + (e?.message ? `: ${e.message}` : ""),
+      );
+      setResultError(true);
+    }
   };
 
-  if(!form) return null;
+  if (!form) return null;
 
   return (
     <Box>
       <h2>{form.name}</h2>
-      {form.fields.map(f => {
+      {form.fields.map((f) => {
         const value = values[f.name];
         return (
           <div key={f.name}>
-            {renderField(f, value, val=>setValues({...values, [f.name]:val}))}
+            {renderField(
+              f,
+              value,
+              (val) => setValues({ ...values, [f.name]: val }),
+              errors[f.name],
+            )}
           </div>
         );
       })}
-      <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+      {resultMsg && (
+        <Alert severity={resultError ? "error" : "success"} sx={{ mb: 2 }}>
+          {resultMsg}
+        </Alert>
+      )}
+      <Button variant="contained" onClick={handleSubmit}>
+        Submit
+      </Button>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add multiline & rows options for text fields in FormBuilder
- store success/failure messages and email options with forms
- validate required fields in FormFill and show result messages
- support multiline text inputs in FormFill

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ee9810408323b3ba8567d12fcd82