### PR TITLE
Add submissions page with export

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "web-vitals": "^2.1.4",
     "y-websocket": "^1.5.0",
     "yjs": "^13.6.8",
-    "yup": "^1.2.0"
+    "yup": "^1.2.0",
+    "xlsx": "^0.18.5",
+    "file-saver": "^2.0.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -48,6 +48,7 @@ const ExpertisePage = lazy(()=>import('./pages/expertisePage')); // Lazy import 
 const FormBuilderPage = lazy(()=>import('./pages/FormBuilderPage'));
 const FormListPage = lazy(()=>import('./pages/FormListPage'));
 const FormFillPage = lazy(()=>import('./pages/FormFillPage'));
+const SubmissionListPage = lazy(()=>import('./pages/SubmissionListPage'));
 
 function App() {
   return (
@@ -93,6 +94,7 @@ function App() {
                 <Route path='/expertise' element={<ExpertisePage />} /> {/* Add the new route */}
                 <Route path='/form/:id?' element={<FormBuilderPage />} />
                 <Route path='/forms' element={<FormListPage />} />
+                <Route path='/submissions' element={<SubmissionListPage />} />
                 <Route path='/form/:id/fill' element={<FormFillPage />} />
                 <Route path="*" element={<UnderConstructionPage />} />
               </Route>

--- a/src/components/apiForms/SubmissionList.js
+++ b/src/components/apiForms/SubmissionList.js
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Pagination, Select, MenuItem, Button, Box } from '@mui/material';
+import { getForms, getSubmissions } from '../../api';
+import { saveAs } from 'file-saver';
+import * as XLSX from 'xlsx';
+
+export default function SubmissionList() {
+  const [forms, setForms] = useState([]);
+  const [selectedForm, setSelectedForm] = useState('');
+  const [submissions, setSubmissions] = useState([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(0);
+  const limit = 10;
+
+  useEffect(() => { fetchForms(); }, []);
+
+  useEffect(() => { if(selectedForm) fetchSubmissions(); }, [selectedForm, page]);
+
+  const fetchForms = async () => {
+    const data = await getForms({ page:1, limit:1000 });
+    setForms(data.forms || []);
+  };
+
+  const fetchSubmissions = async () => {
+    const data = await getSubmissions(selectedForm, { page, limit });
+    setSubmissions(data.submissions || []);
+    setTotalPages(Math.ceil((data.total || 0) / limit));
+  };
+
+  const handleExportCSV = () => {
+    if(submissions.length===0) return;
+    const headers = Object.keys(submissions[0]);
+    const rows = submissions.map(s => headers.map(h => JSON.stringify(s[h] ?? '')).join(','));
+    const csv = [headers.join(','), ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    saveAs(blob, 'submissions.csv');
+  };
+
+  const handleExportXLSX = () => {
+    if(submissions.length===0) return;
+    const ws = XLSX.utils.json_to_sheet(submissions);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Submissions');
+    const xlsBuffer = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+    const blob = new Blob([xlsBuffer], { type: 'application/octet-stream' });
+    saveAs(blob, 'submissions.xlsx');
+  };
+
+  const renderCell = (value) => {
+    if(Array.isArray(value)) return value.join(', ');
+    if(typeof value === 'object' && value !== null) return JSON.stringify(value);
+    return String(value);
+  };
+
+  return (
+    <Box>
+      <Select
+        value={selectedForm}
+        onChange={(e)=>{setSelectedForm(e.target.value); setPage(1);}}
+        displayEmpty
+        sx={{ mb:2, minWidth:200 }}
+      >
+        <MenuItem value="">Select Form</MenuItem>
+        {forms.map(f=>(<MenuItem key={f._id} value={f._id}>{f.name}</MenuItem>))}
+      </Select>
+      {selectedForm && (
+        <>
+          <Box sx={{ mb:2 }}>
+            <Button onClick={handleExportCSV} sx={{mr:1}} variant="outlined">Export CSV</Button>
+            <Button onClick={handleExportXLSX} variant="outlined">Export XLSX</Button>
+          </Box>
+          <TableContainer>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  {submissions.length>0 && Object.keys(submissions[0]).map(key=> (
+                    <TableCell key={key}>{key}</TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {submissions.map((sub,idx)=>(
+                  <TableRow key={sub._id || idx}>
+                    {Object.keys(submissions[0]||{}).map(k=> (
+                      <TableCell key={k}>{renderCell(sub[k])}</TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <Pagination count={totalPages} page={page} onChange={(e,v)=>setPage(v)} sx={{ mt:2 }} />
+        </>
+      )}
+    </Box>
+  );
+}

--- a/src/components/menuItems/useMenuItems.js
+++ b/src/components/menuItems/useMenuItems.js
@@ -373,6 +373,14 @@ const expertiseMenu = {
             url: '/forms',
             target: true,
             requiredPermission: ['viewForms']
+          },
+          {
+            id: 'submissions',
+            title: t('Submissions'),
+            type: 'item',
+            url: '/submissions',
+            target: true,
+            requiredPermission: ['viewFormSubmissions']
           }
         ]
       }

--- a/src/pages/SubmissionListPage.js
+++ b/src/pages/SubmissionListPage.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Container, Typography } from '@mui/material';
+import SubmissionList from '../components/apiForms/SubmissionList';
+
+export default function SubmissionListPage() {
+  return (
+    <Container sx={{ p:4 }}>
+      <Typography variant="h4" gutterBottom>Submissions</Typography>
+      <SubmissionList />
+    </Container>
+  );
+}

--- a/src/translations/en/translation.json
+++ b/src/translations/en/translation.json
@@ -126,6 +126,8 @@
   "Provider":"Provider",
   "Create Video":"Create Video",
   "Update Video":"Update Video",
-  "Videos":"Videos"
+  "Videos":"Videos",
+  "Forms":"Forms",
+  "Submissions":"Submissions"
 
 }

--- a/src/translations/tr/translation.json
+++ b/src/translations/tr/translation.json
@@ -129,5 +129,7 @@
   "Provider":"Sağlayıcı",
   "Create Video":"Video Oluştur",
   "Update Video":"Video Güncelle",
-  "Videos":"Videolar"
+  "Videos":"Videolar",
+  "Forms":"Formlar",
+  "Submissions":"Gönderimler"
 }


### PR DESCRIPTION
## Summary
- add SubmissionList component and page
- allow navigation to submissions page
- export submissions data as CSV or XLSX
- update menu and translations
- include xlsx and file-saver packages

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f0f97c2483239e4cf8cb86fdd877