### PR TITLE
Improve submissions export via backend

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1252,3 +1252,19 @@ export const getSubmissions = async (formId, params = {}) => {
   const response = await instance.get(`/api/forms/${formId}/submissions`, { params });
   return response.data;
 };
+
+export const exportSubmissionsFile = async (
+  formId,
+  format = 'csv',
+  onDownloadProgress,
+) => {
+  const response = await instance.get(
+    `/api/forms/${formId}/submissions/export`,
+    {
+      params: { format },
+      responseType: 'blob',
+      onDownloadProgress,
+    },
+  );
+  return response.data;
+};

--- a/src/components/apiForms/FormList.js
+++ b/src/components/apiForms/FormList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, IconButton, TextField, Pagination, Button } from '@mui/material';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, IconButton, TextField, Pagination, Button, Grid } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { getForms, deleteForm } from '../../api';
@@ -29,8 +29,14 @@ export default function FormList() {
 
   return (
     <TableContainer>
-      <TextField placeholder="Search" value={search} onChange={e=>setSearch(e.target.value)} sx={{ my:2 }} />
-      <Button onClick={()=>navigate('/form')}>New Form</Button>
+      <Grid container spacing={2} sx={{ my:2 }} alignItems="center">
+        <Grid item xs={12} md={6}>
+          <TextField placeholder="Search" size="small" fullWidth value={search} onChange={e=>setSearch(e.target.value)} />
+        </Grid>
+        <Grid item xs={6} md={3}>
+          <Button fullWidth variant="contained" onClick={()=>navigate('/form')}>New Form</Button>
+        </Grid>
+      </Grid>
       <Table>
         <TableHead>
           <TableRow>
@@ -45,7 +51,11 @@ export default function FormList() {
             <TableRow key={form._id}>
               <TableCell>{form.name}</TableCell>
               <TableCell>{new Date(form.createdAt).toLocaleDateString()}</TableCell>
-              <TableCell>{form.submissionCount || 0}</TableCell>
+              <TableCell>
+                <Button variant="outlined" size="small" onClick={() => navigate(`/submissions?formId=${form._id}`)}>
+                  {form.submissionCount || 0}
+                </Button>
+              </TableCell>
               <TableCell>
                 <IconButton onClick={()=>navigate(`/form/${form._id}`)}><EditIcon/></IconButton>
                 <IconButton onClick={()=>handleDelete(form._id, form.submissionCount)} disabled={form.submissionCount>0}><DeleteIcon/></IconButton>

--- a/src/components/apiForms/SubmissionList.js
+++ b/src/components/apiForms/SubmissionList.js
@@ -1,18 +1,44 @@
 import React, { useEffect, useState } from 'react';
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Pagination, Select, MenuItem, Button, Box } from '@mui/material';
-import { getForms, getSubmissions } from '../../api';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Pagination,
+  Select,
+  MenuItem,
+  Button,
+  Box,
+  Grid,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  LinearProgress,
+} from '@mui/material';
+import { getForms, getSubmissions, exportSubmissionsFile } from '../../api';
 import { saveAs } from 'file-saver';
-import * as XLSX from 'xlsx';
+import { useSearchParams } from 'react-router-dom';
 
 export default function SubmissionList() {
+  const [searchParams] = useSearchParams();
+  const initialFormId = searchParams.get('formId') || '';
   const [forms, setForms] = useState([]);
-  const [selectedForm, setSelectedForm] = useState('');
+  const [selectedForm, setSelectedForm] = useState(initialFormId);
   const [submissions, setSubmissions] = useState([]);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(0);
   const limit = 10;
+  const [exporting, setExporting] = useState(false);
+  const [downloadProgress, setDownloadProgress] = useState(0);
 
   useEffect(() => { fetchForms(); }, []);
+
+  useEffect(() => {
+    const param = searchParams.get('formId');
+    if (param) setSelectedForm(param);
+  }, [searchParams]);
 
   useEffect(() => { if(selectedForm) fetchSubmissions(); }, [selectedForm, page]);
 
@@ -27,26 +53,41 @@ export default function SubmissionList() {
     setTotalPages(Math.ceil((data.total || 0) / limit));
   };
 
-  const handleExportCSV = () => {
-    if(submissions.length===0) return;
-    const headers = Object.keys(submissions[0]);
-    const rows = submissions.map(s => headers.map(h => JSON.stringify(s[h] ?? '')).join(','));
-    const csv = [headers.join(','), ...rows].join('\n');
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    saveAs(blob, 'submissions.csv');
+  const hiddenFields = ['createdBy', '__v', '_id', 'form'];
+
+  const getHeaders = () =>
+    submissions.length > 0
+      ? Object.keys(submissions[0]).filter((h) => !hiddenFields.includes(h))
+      : [];
+
+  const handleExport = async (format) => {
+    if (exporting) return;
+    setExporting(true);
+    setDownloadProgress(0);
+    try {
+      const blob = await exportSubmissionsFile(
+        selectedForm,
+        format,
+        (e) => {
+          if (e.total) {
+            setDownloadProgress(Math.round((e.loaded * 100) / e.total));
+          }
+        },
+      );
+      saveAs(blob, `submissions.${format === 'xlsx' ? 'xlsx' : 'csv'}`);
+    } catch (err) {
+      console.error('Export error', err);
+    } finally {
+      setExporting(false);
+    }
   };
 
-  const handleExportXLSX = () => {
-    if(submissions.length===0) return;
-    const ws = XLSX.utils.json_to_sheet(submissions);
-    const wb = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(wb, ws, 'Submissions');
-    const xlsBuffer = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
-    const blob = new Blob([xlsBuffer], { type: 'application/octet-stream' });
-    saveAs(blob, 'submissions.xlsx');
-  };
-
-  const renderCell = (value) => {
+  const renderCell = (key, value) => {
+    if(key === 'data' && typeof value === 'object' && value !== null) {
+      const entries = Object.entries(value).slice(0,3).map(([k,v])=>`${k}: ${v}`);
+      const suffix = Object.keys(value).length > 3 ? ', ...' : '';
+      return entries.join(', ') + suffix;
+    }
     if(Array.isArray(value)) return value.join(', ');
     if(typeof value === 'object' && value !== null) return JSON.stringify(value);
     return String(value);
@@ -54,26 +95,37 @@ export default function SubmissionList() {
 
   return (
     <Box>
-      <Select
-        value={selectedForm}
-        onChange={(e)=>{setSelectedForm(e.target.value); setPage(1);}}
-        displayEmpty
-        sx={{ mb:2, minWidth:200 }}
-      >
-        <MenuItem value="">Select Form</MenuItem>
-        {forms.map(f=>(<MenuItem key={f._id} value={f._id}>{f.name}</MenuItem>))}
-      </Select>
+      <Grid container spacing={2} sx={{ mb:2 }} alignItems="center">
+        <Grid item xs={12} md={6}>
+          <Select
+            size="small"
+            fullWidth
+            value={selectedForm}
+            onChange={(e)=>{setSelectedForm(e.target.value); setPage(1);}}
+            displayEmpty
+          >
+            <MenuItem value="">Select Form</MenuItem>
+            {forms.map(f=>(<MenuItem key={f._id} value={f._id}>{f.name}</MenuItem>))}
+          </Select>
+        </Grid>
+        {selectedForm && (
+          <>
+            <Grid item xs={6} md={3}>
+              <Button onClick={() => handleExport('csv')} fullWidth variant="outlined" disabled={exporting}>Export CSV</Button>
+            </Grid>
+            <Grid item xs={6} md={3}>
+              <Button onClick={() => handleExport('xlsx')} fullWidth variant="outlined" disabled={exporting}>Export XLSX</Button>
+            </Grid>
+          </>
+        )}
+      </Grid>
       {selectedForm && (
         <>
-          <Box sx={{ mb:2 }}>
-            <Button onClick={handleExportCSV} sx={{mr:1}} variant="outlined">Export CSV</Button>
-            <Button onClick={handleExportXLSX} variant="outlined">Export XLSX</Button>
-          </Box>
           <TableContainer>
             <Table>
               <TableHead>
                 <TableRow>
-                  {submissions.length>0 && Object.keys(submissions[0]).map(key=> (
+                {getHeaders().map(key => (
                     <TableCell key={key}>{key}</TableCell>
                   ))}
                 </TableRow>
@@ -81,8 +133,8 @@ export default function SubmissionList() {
               <TableBody>
                 {submissions.map((sub,idx)=>(
                   <TableRow key={sub._id || idx}>
-                    {Object.keys(submissions[0]||{}).map(k=> (
-                      <TableCell key={k}>{renderCell(sub[k])}</TableCell>
+                    {getHeaders().map(k=> (
+                      <TableCell key={k}>{renderCell(k, sub[k])}</TableCell>
                     ))}
                   </TableRow>
                 ))}
@@ -92,6 +144,17 @@ export default function SubmissionList() {
           <Pagination count={totalPages} page={page} onChange={(e,v)=>setPage(v)} sx={{ mt:2 }} />
         </>
       )}
+      <Dialog open={exporting}>
+        <DialogTitle>Exporting...</DialogTitle>
+        <DialogContent>
+          <Box sx={{ minWidth: 200 }}>
+            <LinearProgress
+              variant={downloadProgress ? 'determinate' : 'indeterminate'}
+              value={downloadProgress}
+            />
+          </Box>
+        </DialogContent>
+      </Dialog>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add API helper to download submission exports
- switch SubmissionList to use backend export with streaming progress
- show export progress with a modal dialog

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f9a6b4608323a074f67503ae0838