### PR TITLE
Fix multiselect value submission

### DIFF
--- a/src/components/apiForms/FormFill.js
+++ b/src/components/apiForms/FormFill.js
@@ -186,7 +186,8 @@ export default function FormFill() {
       const submitValues = { ...values };
       form.fields.forEach((f) => {
         if (f.type === "multiselect") {
-          submitValues[f.name] = (values[f.name] || []).join(";");
+          // Backend expects an array for multiselect fields
+          submitValues[f.name] = values[f.name] || [];
         }
         if (f.type === "html" && !f.withCheckbox) {
           delete submitValues[f.name];


### PR DESCRIPTION
## Summary
- keep multiselect values as arrays when submitting forms

## Testing
- `npm test --silent -- -u` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6869265412dc8323a031b7537a7cd383