### PR TITLE
Improve form builder features

### DIFF
--- a/src/components/apiForms/FormBuilder.js
+++ b/src/components/apiForms/FormBuilder.js
@@ -21,6 +21,7 @@ const emptyField = {
   label: "",
   type: "text",
   required: false,
+  unique: false,
   options: [],
   minLength: "",
   maxLength: "",
@@ -113,6 +114,28 @@ function FieldEditor({ field, onChange, onDelete }) {
               <Button size="small" onClick={() => onChange({ ...field, options: [...field.options, ''] })}>
                 {t('add_option')}
               </Button>
+              <Button size="small" component="label" sx={{ ml: 1 }}>
+                {t('import_options')}
+                <input
+                  type="file"
+                  hidden
+                  onChange={(e) => {
+                    const file = e.target.files[0];
+                    if (!file) return;
+                    const reader = new FileReader();
+                    reader.onload = () => {
+                      const text = reader.result;
+                      const opts = text
+                        .split(';')
+                        .map((o) => o.trim())
+                        .filter((o) => o);
+                      onChange({ ...field, options: opts });
+                    };
+                    reader.readAsText(file);
+                    e.target.value = '';
+                  }}
+                />
+              </Button>
             </Box>
           )}
           {field.type === "text" && (
@@ -181,6 +204,18 @@ function FieldEditor({ field, onChange, onDelete }) {
             }
             label={t('required')}
           />
+          {(field.type === 'text' || field.type === 'number' || field.type === 'datetime') && (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={field.unique}
+                  onChange={handleChange}
+                  name="unique"
+                />
+              }
+              label={t('unique')}
+            />
+          )}
         </Grid>
         <Grid item xs={1}>
           <IconButton onClick={onDelete}>

--- a/src/components/apiForms/FormFill.js
+++ b/src/components/apiForms/FormFill.js
@@ -125,6 +125,7 @@ function renderField(field, value, setValue, error) {
           error={error}
           fullWidth
           sx={{ mb: 2 }}
+          InputLabelProps={{ shrink: true }}
         />
       );
     case "html":

--- a/src/translations/en/translation.json
+++ b/src/translations/en/translation.json
@@ -149,4 +149,6 @@
   ,"include_checkbox":"Include Checkbox"
   ,"submitted":"Submitted"
   ,"submission_failed":"Submission failed"
+  ,"unique":"Unique"
+  ,"import_options":"Import Options"
 }

--- a/src/translations/tr/translation.json
+++ b/src/translations/tr/translation.json
@@ -151,4 +151,6 @@
   ,"include_checkbox":"Onay Kutusu Ekle"
   ,"submitted":"Gönderildi"
   ,"submission_failed":"Gönderim başarısız"
+  ,"unique":"Benzersiz"
+  ,"import_options":"Seçenekleri İçe Aktar"
 }


### PR DESCRIPTION
## Summary
- allow unique flag on text, number and datetime fields
- import select options from a file
- keep date and datetime labels shrunk
- update translations for new labels

## Testing
- `npm test -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869406ad00883239009a1d6f203d189