### PR TITLE
Add helper text editing to form builder

### DIFF
--- a/src/components/apiForms/FormBuilder.js
+++ b/src/components/apiForms/FormBuilder.js
@@ -35,6 +35,7 @@ const emptyField = {
   htmlContent: "",
   withCheckbox: false,
   groups: null,
+  helperText: { text: "", type: "info" },
 };
 
 const fieldTypes = [
@@ -75,6 +76,33 @@ function FieldEditor({ field, onChange, onDelete }) {
             fullWidth
             sx={{ mb: 1 }}
           />
+          <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
+            <TextField
+              label={t('helper_text')}
+              value={field.helperText?.text || ''}
+              onChange={(e) =>
+                onChange({
+                  ...field,
+                  helperText: { ...field.helperText, text: e.target.value },
+                })
+              }
+              fullWidth
+            />
+            <Select
+              value={field.helperText?.type || 'info'}
+              onChange={(e) =>
+                onChange({
+                  ...field,
+                  helperText: { ...field.helperText, type: e.target.value },
+                })
+              }
+              sx={{ width: 120 }}
+              size="small"
+            >
+              <MenuItem value="info">{t('info')}</MenuItem>
+              <MenuItem value="error">{t('error')}</MenuItem>
+            </Select>
+          </Box>
           <Select
             name="type"
             value={field.type}

--- a/src/components/apiForms/FormFill.js
+++ b/src/components/apiForms/FormFill.js
@@ -11,6 +11,7 @@ import {
   Alert,
   FormControl,
   InputLabel,
+  FormHelperText,
   Typography,
 } from "@mui/material";
 import { getFormById, createSubmission } from "../../api";
@@ -42,7 +43,7 @@ function OptionsField({ field, value, setValue, isRadio }) {
           <Button size="small" onClick={() => setExpanded(!expanded)}>
             {expanded ? t("hide") : t("show")}
           </Button>
-        </Box>,
+        </Box>
       );
       if (!expanded) return;
     }
@@ -59,14 +60,19 @@ function OptionsField({ field, value, setValue, isRadio }) {
           />
         }
         label={opt}
-      />,
-    );
+      />
+      );
   });
 
   return (
     <Box sx={{ mb: 2 }}>
       {!isRadio && <InputLabel sx={{ mb: 1 }}>{field.label}</InputLabel>}
       {elements}
+      {field.helperText?.text && (
+        <FormHelperText error={field.helperText.type === 'error'}>
+          {field.helperText.text}
+        </FormHelperText>
+      )}
     </Box>
   );
 }
@@ -82,9 +88,20 @@ function renderField(field, value, setValue, error) {
     setValue(val);
   };
 
+  const wrap = (element) => (
+    <Box sx={{ mb: 2 }}>
+      {element}
+      {field.helperText?.text && (
+        <FormHelperText error={field.helperText.type === 'error'}>
+          {field.helperText.text}
+        </FormHelperText>
+      )}
+    </Box>
+  );
+
   switch (field.type) {
     case "text":
-      return (
+      return wrap(
         <TextField
           label={field.label}
           value={value || ""}
@@ -94,11 +111,10 @@ function renderField(field, value, setValue, error) {
           multiline={field.multiline}
           rows={field.multiline ? field.rows || 3 : undefined}
           fullWidth
-          sx={{ mb: 2 }}
         />
       );
     case "number":
-      return (
+      return wrap(
         <TextField
           type="number"
           label={field.label}
@@ -107,12 +123,11 @@ function renderField(field, value, setValue, error) {
           required={field.required}
           error={error}
           fullWidth
-          sx={{ mb: 2 }}
         />
       );
     case "select":
-      return (
-        <FormControl fullWidth sx={{ mb: 2 }} error={error}>
+      return wrap(
+        <FormControl fullWidth error={error}>
           <InputLabel>{field.label}</InputLabel>
           <Select
             value={value || ""}
@@ -129,7 +144,7 @@ function renderField(field, value, setValue, error) {
         </FormControl>
       );
     case "multiselect":
-      return (
+      return wrap(
         <OptionsField
           field={field}
           value={value}
@@ -138,7 +153,7 @@ function renderField(field, value, setValue, error) {
         />
       );
     case "radio":
-      return (
+      return wrap(
         <OptionsField
           field={field}
           value={value}
@@ -148,7 +163,7 @@ function renderField(field, value, setValue, error) {
       );
     case "date":
     case "datetime":
-      return (
+      return wrap(
         <TextField
           type="date"
           label={field.label}
@@ -157,13 +172,12 @@ function renderField(field, value, setValue, error) {
           required={field.required}
           error={error}
           fullWidth
-          sx={{ mb: 2 }}
           InputLabelProps={{ shrink: true }}
         />
       );
     case "html":
-      return (
-        <Box sx={{ mb: 2 }}>
+      return wrap(
+        <Box>
           {field.htmlContent && (
             <div dangerouslySetInnerHTML={{ __html: field.htmlContent }} />
           )}

--- a/src/translations/en/translation.json
+++ b/src/translations/en/translation.json
@@ -153,5 +153,9 @@
   "import_options": "Import Options",
   "groups": "Groups",
   "show": "Show",
-  "hide": "Hide"
+  "hide": "Hide",
+  "helper_text": "Helper Text",
+  "helper_type": "Helper Type",
+  "info": "Info",
+  "error": "Error"
 }

--- a/src/translations/tr/translation.json
+++ b/src/translations/tr/translation.json
@@ -155,5 +155,9 @@
   "import_options": "Seçenekleri İçe Aktar",
   "groups": "Gruplar",
   "show": "Göster",
-  "hide": "Gizle"
+  "hide": "Gizle",
+  "helper_text": "Yardım Metni",
+  "helper_type": "Mesaj Tipi",
+  "info": "Bilgi",
+  "error": "Hata"
 }


### PR DESCRIPTION
## Summary
- extend form field schema with `helperText` info
- allow editing helper text and type in the form builder
- render helper messages in form fill screens
- add translations for helper text editing

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e95320644832383fb43dfe1e65f3c