### PR TITLE
Enable editing and deleting form submissions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -95,7 +95,7 @@ function App() {
                 <Route path='/form/:id?' element={<FormBuilderPage />} />
                 <Route path='/forms' element={<FormListPage />} />
                 <Route path='/submissions' element={<SubmissionListPage />} />
-                <Route path='/form/:id/fill' element={<FormFillPage />} />
+                <Route path='/form/:id/fill/:submissionId?' element={<FormFillPage />} />
                 <Route path="*" element={<UnderConstructionPage />} />
               </Route>
             </Routes>

--- a/src/api.js
+++ b/src/api.js
@@ -1268,3 +1268,25 @@ export const exportSubmissionsFile = async (
   );
   return response.data;
 };
+
+export const getSubmission = async (formId, submissionId) => {
+  const response = await instance.get(
+    `/api/forms/${formId}/submissions/${submissionId}`,
+  );
+  return response.data;
+};
+
+export const updateFormSubmission = async (formId, submissionId, data) => {
+  const response = await instance.put(
+    `/api/forms/${formId}/submissions/${submissionId}`,
+    data,
+  );
+  return response.data;
+};
+
+export const deleteFormSubmission = async (formId, submissionId) => {
+  const response = await instance.delete(
+    `/api/forms/${formId}/submissions/${submissionId}`,
+  );
+  return response.data;
+};

--- a/src/components/apiForms/FormFill.js
+++ b/src/components/apiForms/FormFill.js
@@ -17,7 +17,12 @@ import {
   Step,
   StepLabel,
 } from "@mui/material";
-import { getFormById, createSubmission } from "../../api";
+import {
+  getFormById,
+  createSubmission,
+  getSubmission,
+  updateFormSubmission,
+} from "../../api";
 import { useParams } from "react-router-dom";
 
 function OptionsField({ field, value, setValue, isRadio, error }) {
@@ -207,7 +212,7 @@ function renderField(field, value, setValue, error) {
   }
 }
 
-export default function FormFill() {
+export default function FormFill({ submissionId }) {
   const { id } = useParams();
   const { t } = useTranslation();
   const [form, setForm] = useState(null);
@@ -220,6 +225,16 @@ export default function FormFill() {
   useEffect(() => {
     getFormById(id).then((data) => setForm(data));
   }, [id]);
+
+  useEffect(() => {
+    if (submissionId) {
+      getSubmission(id, submissionId).then((data) => {
+        setValues(data.data || {});
+      });
+    } else {
+      setValues({});
+    }
+  }, [id, submissionId]);
 
   const validateField = (field, val) => {
     if (field.type === "html" && !field.withCheckbox) return "";
@@ -326,7 +341,11 @@ export default function FormFill() {
           delete submitValues[f.name];
         }
       });
-      await createSubmission(id, submitValues);
+      if (submissionId) {
+        await updateFormSubmission(id, submissionId, submitValues);
+      } else {
+        await createSubmission(id, submitValues);
+      }
       const msg = form.successMessage || t("submitted");
       setResultMsg(replacePlaceholders(msg, submitValues));
       setResultError(false);

--- a/src/components/apiForms/SubmissionList.js
+++ b/src/components/apiForms/SubmissionList.js
@@ -10,6 +10,7 @@ import {
   Select,
   MenuItem,
   Button,
+  IconButton,
   Box,
   Grid,
   Dialog,
@@ -17,9 +18,17 @@ import {
   DialogContent,
   LinearProgress,
 } from '@mui/material';
-import { getForms, getSubmissions, exportSubmissionsFile } from '../../api';
+import {
+  getForms,
+  getSubmissions,
+  exportSubmissionsFile,
+  deleteFormSubmission,
+} from '../../api';
 import { saveAs } from 'file-saver';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useAuth } from '../../context/AuthContext';
 
 export default function SubmissionList() {
   const [searchParams] = useSearchParams();
@@ -32,6 +41,8 @@ export default function SubmissionList() {
   const limit = 10;
   const [exporting, setExporting] = useState(false);
   const [downloadProgress, setDownloadProgress] = useState(0);
+  const navigate = useNavigate();
+  const { hasPermission } = useAuth();
 
   useEffect(() => { fetchForms(); }, []);
 
@@ -82,6 +93,12 @@ export default function SubmissionList() {
     }
   };
 
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete submission?')) return;
+    await deleteFormSubmission(selectedForm, id);
+    fetchSubmissions();
+  };
+
   const renderCell = (key, value) => {
     if(key === 'data' && typeof value === 'object' && value !== null) {
       const entries = Object.entries(value).slice(0,3).map(([k,v])=>`${k}: ${v}`);
@@ -92,6 +109,10 @@ export default function SubmissionList() {
     if(typeof value === 'object' && value !== null) return JSON.stringify(value);
     return String(value);
   };
+
+  const showActions =
+    hasPermission('updateFormSubmission') ||
+    hasPermission('deleteFormSubmission');
 
   return (
     <Box>
@@ -128,6 +149,7 @@ export default function SubmissionList() {
                 {getHeaders().map(key => (
                     <TableCell key={key}>{key}</TableCell>
                   ))}
+                {showActions && <TableCell>Actions</TableCell>}
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -136,6 +158,22 @@ export default function SubmissionList() {
                     {getHeaders().map(k=> (
                       <TableCell key={k}>{renderCell(k, sub[k])}</TableCell>
                     ))}
+                    {showActions && (
+                      <TableCell>
+                        {hasPermission('updateFormSubmission') && (
+                          <IconButton onClick={() => navigate(`/form/${selectedForm}/fill/${sub._id}`)}>
+                            <EditIcon />
+                          </IconButton>
+                        )}
+                        {hasPermission('deleteFormSubmission') && (
+                          <IconButton
+                            onClick={() => handleDelete(sub._id)}
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        )}
+                      </TableCell>
+                    )}
                   </TableRow>
                 ))}
               </TableBody>

--- a/src/pages/FormFillPage.js
+++ b/src/pages/FormFillPage.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Container } from '@mui/material';
 import FormFill from '../components/apiForms/FormFill';
+import { useParams } from 'react-router-dom';
 
 export default function FormFillPage() {
+  const { submissionId } = useParams();
   return (
-    <Container sx={{p:4}}>
-      <FormFill />
+    <Container sx={{ p: 4 }}>
+      <FormFill submissionId={submissionId} />
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- add API helpers for CRUD operations on form submissions
- load and update submissions in form fill component
- support optional submissionId parameter in form fill page and route
- display Edit/Delete buttons for submissions when user has permission

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f948b4cd083238bd197057f28f212