### PR TITLE
Fix form prefill for editing

### DIFF
--- a/src/components/apiForms/FormBuilder.js
+++ b/src/components/apiForms/FormBuilder.js
@@ -298,12 +298,13 @@ export default function FormBuilder({ formId, onSaved }) {
       setLoading(true);
       getFormById(formId)
         .then((data) => {
-          setName(data.name);
-          setFields(data.fields || []);
-          setSuccessMessage(data.successMessage || "");
-          setFailureMessage(data.failureMessage || "");
-          setSendEmail(data.sendEmail || false);
-          setEmailTo(data.emailTo || "");
+          const form = data.form || data;
+          setName(form.name || "");
+          setFields(form.fields || []);
+          setSuccessMessage(form.successMessage || "");
+          setFailureMessage(form.failureMessage || "");
+          setSendEmail(form.sendEmail || false);
+          setEmailTo(form.emailTo || "");
         })
         .finally(() => setLoading(false));
     }


### PR DESCRIPTION
## Summary
- ensure FormBuilder handles API responses with either `form` or direct data

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9951a0d48323ab47c258c3be2b1c