### PR TITLE
Add form submission editing support

### DIFF
--- a/src/components/apiForms/FormFill.js
+++ b/src/components/apiForms/FormFill.js
@@ -17,7 +17,12 @@ import {
   Step,
   StepLabel,
 } from "@mui/material";
-import { getFormById, createSubmission } from "../../api";
+import {
+  getFormById,
+  createSubmission,
+  getSubmission,
+  updateFormSubmission,
+} from "../../api";
 import { useParams } from "react-router-dom";
 
 function OptionsField({ field, value, setValue, isRadio, error }) {
@@ -207,7 +212,7 @@ function renderField(field, value, setValue, error) {
   }
 }
 
-export default function FormFill() {
+export default function FormFill({ submissionId }) {
   const { id } = useParams();
   const { t } = useTranslation();
   const [form, setForm] = useState(null);
@@ -220,6 +225,15 @@ export default function FormFill() {
   useEffect(() => {
     getFormById(id).then((data) => setForm(data));
   }, [id]);
+
+  useEffect(() => {
+    if (!submissionId) return;
+    getSubmission(id, submissionId).then((sub) => {
+      if (!sub) return;
+      const data = sub.data || sub;
+      setValues(data);
+    });
+  }, [id, submissionId]);
 
   const validateField = (field, val) => {
     if (field.type === "html" && !field.withCheckbox) return "";
@@ -326,7 +340,11 @@ export default function FormFill() {
           delete submitValues[f.name];
         }
       });
-      await createSubmission(id, submitValues);
+      if (submissionId) {
+        await updateFormSubmission(id, submissionId, submitValues);
+      } else {
+        await createSubmission(id, submitValues);
+      }
       const msg = form.successMessage || t("submitted");
       setResultMsg(replacePlaceholders(msg, submitValues));
       setResultError(false);


### PR DESCRIPTION
## Summary
- prefill `FormFill` when editing an existing submission
- update submission via API if a submission ID is provided

## Testing
- `npm test --silent -- -u --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9c29480c8323881aa7fc9ad1918f